### PR TITLE
Adding sandbox environment to available configuration option and updating the address to the staging URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 #   gem "activesupport", ">= 2.3.5"
 
 gem "faraday"
-gem "faraday_middleware"
+gem "faraday_middleware", '~> 0.7'
 gem "hashie"
 gem "multi_json", "~> 1.0.1"
 gem "yajl-ruby"

--- a/lib/just_giving.rb
+++ b/lib/just_giving.rb
@@ -9,4 +9,4 @@ require 'just_giving/event'
 require 'just_giving/fundraising'
 require 'just_giving/search'
 require 'just_giving/donation'
-require 'just_giving/railtie' if defined?(Rails)
+require 'just_giving/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3

--- a/lib/just_giving/configuration.rb
+++ b/lib/just_giving/configuration.rb
@@ -15,7 +15,7 @@ module JustGiving
       @@application_id = id
     end
 
-    ## This can be either :staging or :production and sets what endpoint to use
+    ## This can be :sandbox, :staging or :production and sets what endpoint to use
     def self.environment=(env)
       @@environment = env
     end
@@ -27,7 +27,11 @@ module JustGiving
     ## The API endpoint
     def self.api_endpoint
       raise JustGiving::InvalidApplicationId.new if !application_id
-      environment == :staging ? "https://api.staging.justgiving.com/#{application_id}" : "https://api.justgiving.com/#{application_id}"
+      case environment
+        when :sandbox then "https://api-sandbox.justgiving.com/#{application_id}"
+        when :staging then "https://api-staging.justgiving.com/#{application_id}"
+        else "https://api.justgiving.com/#{application_id}"
+      end
     end
 
     ## Path to the systems CA cert bundles

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -10,14 +10,18 @@ class TestConfiguration < Test::Unit::TestCase
   
   should 'allow setting the enviroment' do
     assert_equal :staging, JustGiving::Configuration.environment
+    JustGiving::Configuration.environment = :sandbox
+    assert_equal :sandbox, JustGiving::Configuration.environment
     JustGiving::Configuration.environment = :production
     assert_equal :production, JustGiving::Configuration.environment
   end
   
   should 'return the api endpoint' do
-    JustGiving::Configuration.environment = :staging    
     JustGiving::Configuration.application_id = '5678'
-    assert_equal 'https://api.staging.justgiving.com/5678', JustGiving::Configuration.api_endpoint
+    JustGiving::Configuration.environment = :sandbox
+    assert_equal 'https://api-sandbox.justgiving.com/5678', JustGiving::Configuration.api_endpoint
+    JustGiving::Configuration.environment = :staging
+    assert_equal 'https://api-staging.justgiving.com/5678', JustGiving::Configuration.api_endpoint
     JustGiving::Configuration.environment = :production
     assert_equal 'https://api.justgiving.com/5678', JustGiving::Configuration.api_endpoint
   end


### PR DESCRIPTION
Hi,

I've updated the library as it seems that Just Giving have created a new sandbox environment and changed the URL for the staging environment:
https://api.justgiving.com/docs/usage#environments

I had to fix faraday_middleware back to 0.7 as it looks like it's API has changed - not sure if there's a neater way to handle this...

Cheers,
Patrick
